### PR TITLE
chore: upgrade pnpm to v11 and add minimumReleaseAge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
-          version: latest
           run_install: false
 
       - name: 📦 Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-ignore-workspace-root-check=true

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
-  "packageManager": "pnpm@10.30.1",
+  "packageManager": "pnpm@11.1.3",
   "dependencies": {
     "@nuxt/content": "^3.11.2",
     "@nuxt/devtools": "3.2.1",
@@ -38,16 +38,5 @@
     "@nuxt/eslint-config": "1.15.1",
     "automd": "0.4.3",
     "eslint": "9.39.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "sharp"
-    ],
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "vue-demi"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,16 @@ allowBuilds:
   vue-demi: false
   better-sqlite3: true
   sharp: true
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  # Nuxt
+  - '@nuxt/*'
+  - '@nuxtjs/*'
+  - 'nuxt'
+  - 'nuxt-*'
+  # Vercel
+  - '@vercel/*'
+  - '@ai-sdk/*'
+  - 'ai'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ allowBuilds:
   vue-demi: false
   better-sqlite3: true
   sharp: true
+  unrs-resolver: false
 
 minimumReleaseAge: 2880
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+shamefullyHoist: true
+ignoreWorkspaceRootCheck: true
+
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  vue-demi: false
+  better-sqlite3: true
+  sharp: true


### PR DESCRIPTION
## Summary

Two related changes to harden the supply chain and modernize the package manager setup.

### 1. Upgrade pnpm to v11

- Bump `packageManager` to `pnpm@11.1.3`
- Bump `pnpm/action-setup@v2` → `@v6` in workflows; remove pinned `version: latest`
- Migrate `onlyBuiltDependencies` + `ignoredBuiltDependencies` from `package.json` → `allowBuilds` map in new `pnpm-workspace.yaml` (the `pnpm` field in `package.json` is no longer recognized in v11)
- Move `shamefullyHoist`, `ignoreWorkspaceRootCheck` from `.npmrc` → `pnpm-workspace.yaml`
- Delete `.npmrc` (now empty)

### 2. Add `minimumReleaseAge` to harden supply chain

2-day minimum age (2880 minutes) before any newly published dependency can resolve. Trusted-source allowlist exempts the Nuxt and Vercel ecosystems.

## Test plan
- [ ] `pnpm install` resolves cleanly with v11 (1488 entries pass supply-chain policies via `--lockfile-only`)
- [ ] CI passes: build.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package manager to a newer pnpm release.
  * Removed two legacy npm configuration flags.
  * Upgraded CI package-setup action to a newer version.
  * Added workspace configuration to refine dependency/build behavior and release timing exclusions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/canvas/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->